### PR TITLE
Add 3rd method slices.Equal

### DIFF
--- a/compare_slices.go
+++ b/compare_slices.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"reflect"
+	"slices"
 )
 
 func main() {
@@ -30,4 +31,8 @@ func Equal(a, b []int) bool {
 
 func EqualWithReflect(a, b []int) bool {
 	return reflect.DeepEqual(a, b)
+}
+
+func EqualWithSlices(a, b []int) bool {
+	return slices.Equal(a, b)
 }

--- a/compare_slices_test.go
+++ b/compare_slices_test.go
@@ -18,6 +18,13 @@ func BenchmarkEqualWithReflect4(b *testing.B) {
 	EqualWithReflect(x, y)
 }
 
+func BenchmarkEqualWithSlices4(b *testing.B) {
+	x := []int{1, 2, 3, 4, 5}
+	y := []int{1, 2, 3, 4, 5}
+
+	EqualWithSlices(x, y)
+}
+
 func BenchmarkEqual10000000(b *testing.B) {
 	x := make([]int, 10000000)
 	y := make([]int, 10000000)
@@ -30,6 +37,13 @@ func BenchmarkEqualWithReflect10000000(b *testing.B) {
 	y := make([]int, 10000000)
 
 	EqualWithReflect(x, y)
+}
+
+func BenchmarkEqualWithSlices10000000(b *testing.B) {
+	x := make([]int, 10000000)
+	y := make([]int, 10000000)
+
+	EqualWithSlices(x, y)
 }
 
 func BenchmarkEqualDifferentElements(b *testing.B) {
@@ -50,6 +64,15 @@ func BenchmarkEqualWithReflectDifferentElements(b *testing.B) {
 	EqualWithReflect(x, y)
 }
 
+func BenchmarkEqualWithSlicesDifferentElements(b *testing.B) {
+	x := make([]int, 10000000)
+	y := make([]int, 10000000)
+
+	x[2] = 1
+
+	EqualWithSlices(x, y)
+}
+
 func BenchmarkEqualDifferentLength(b *testing.B) {
 	x := make([]int, 10000000)
 	y := make([]int, 20000000)
@@ -62,4 +85,11 @@ func BenchmarkEqualWithReflectDifferentLength(b *testing.B) {
 	y := make([]int, 20000000)
 
 	EqualWithReflect(x, y)
+}
+
+func BenchmarkEqualWithSlicesDifferentLength(b *testing.B) {
+	x := make([]int, 10000000)
+	y := make([]int, 20000000)
+
+	EqualWithSlices(x, y)
 }


### PR DESCRIPTION
Since golang 1.21 there is a package slices available, that has Equal method for comparing slices.
It was added to comparison.

I got following results for the tests:
```
$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/mihail-i4v/benchmark-go
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkEqual4-8                              	1000000000	         0.0000001 ns/op
BenchmarkEqualWithReflect4-8                   	1000000000	         0.0000027 ns/op
BenchmarkEqualWithSlices4-8                    	1000000000	         0.0000003 ns/op
BenchmarkEqual10000000-8                       	1000000000	         0.04524 ns/op
BenchmarkEqualWithReflect10000000-8            	1000000000	         0.1708 ns/op
BenchmarkEqualWithSlices10000000-8             	1000000000	         0.02456 ns/op
BenchmarkEqualDifferentElements-8              	1000000000	         0.03063 ns/op
BenchmarkEqualWithReflectDifferentElements-8   	1000000000	         0.01034 ns/op
BenchmarkEqualWithSlicesDifferentElements-8    	1000000000	         0.03036 ns/op
BenchmarkEqualDifferentLength-8                	1000000000	         0.01777 ns/op
BenchmarkEqualWithReflectDifferentLength-8     	1000000000	         0.01559 ns/op
BenchmarkEqualWithSlicesDifferentLength-8      	1000000000	         0.03137 ns/op
PASS
ok  	github.com/mihail-i4v/benchmark-go	3.796s
```